### PR TITLE
feat: refresh frontend with logo and cohesive color theme

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -10,6 +10,9 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/svgs/solid/graduation-cap.svg" />
   <style>
     body { font-family: 'Inter', sans-serif; }
   </style>
@@ -17,19 +20,22 @@
 <body class="bg-gray-50">
   <header class="bg-white shadow">
     <div class="max-w-6xl mx-auto p-4 flex justify-between items-center animate__animated animate__fadeInDown">
-      <h1 class="text-2xl font-bold text-indigo-600">TeacherRate Admin</h1>
+      <div class="flex items-center text-blue-700">
+        <i class="fa-solid fa-graduation-cap mr-2 text-3xl"></i>
+        <h1 class="text-2xl font-bold">TeacherRate Admin</h1>
+      </div>
       <nav>
-        <a href="/" class="text-sm text-gray-600 hover:text-indigo-600">Home</a>
+        <a href="/" class="text-sm text-gray-600 hover:text-blue-700">Home</a>
       </nav>
     </div>
   </header>
 
   <main class="max-w-4xl mx-auto p-6">
     <section class="bg-white rounded-lg shadow p-6 mb-8 animate__animated animate__fadeInUp">
-      <h3 class="text-2xl font-semibold mb-4">Add Teacher</h3>
+      <h3 class="text-2xl font-semibold mb-4 text-blue-700">Add Teacher</h3>
       <div class="flex flex-col sm:flex-row gap-2">
         <input id="teacher-name" class="flex-1 p-2 border rounded" placeholder="Name" />
-        <button class="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 transition transform hover:scale-105" onclick="addTeacher()">Add</button>
+        <button class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition transform hover:scale-105" onclick="addTeacher()">Add</button>
       </div>
     </section>
   </main>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -40,7 +40,7 @@ async function loadTeachers() {
 
   teachers.forEach(t => {
     const div = document.createElement('div');
-    div.className = 'bg-white rounded-lg shadow p-6 transition transform hover:-translate-y-1 hover:shadow-lg animate__animated animate__fadeIn';
+    div.className = 'bg-white border border-gray-200 rounded-lg shadow p-6 transition transform hover:-translate-y-1 hover:shadow-lg animate__animated animate__fadeIn';
 
     const ratingHtml = t.averageRating !== null && t.averageRating !== undefined
       ? `<div class="flex items-center mb-4">
@@ -59,12 +59,12 @@ async function loadTeachers() {
 
     // Build card: title, average rating, quick stars, and comment form
     div.innerHTML = `
-      <h3 class="text-xl font-semibold mb-2">${t.name}</h3>
+      <h3 class="text-xl font-semibold mb-2 text-blue-700">${t.name}</h3>
       ${ratingHtml}
 
       <!-- Quick star rating -->
       <div class="flex items-center space-x-2 mb-4">
-        <span class="text-sm text-gray-600">Rate:</span>
+        <span class="text-sm text-blue-700">Rate:</span>
         <div class="flex space-x-1">${renderRateControls(t.id)}</div>
       </div>
 
@@ -76,7 +76,7 @@ async function loadTeachers() {
             <option value="">Rating</option>
             ${[1,2,3,4,5].map(n => `<option value="${n}">${n}</option>`).join('')}
           </select>
-          <button class="bg-indigo-600 text-white px-3 py-1 rounded hover:bg-indigo-700 transition" onclick="submitReview(${t.id})">Submit</button>
+          <button class="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 transition" onclick="submitReview(${t.id})">Submit</button>
         </div>
       </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,9 @@
   <!-- Font Awesome for star icons -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
 
+  <!-- Favicon -->
+  <link rel="icon" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/svgs/solid/graduation-cap.svg" />
+
   <!-- Animations (optional) -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
 
@@ -27,25 +30,28 @@
   <!-- Header -->
   <header class="bg-white shadow">
     <div class="max-w-6xl mx-auto p-4 flex justify-between items-center">
-      <h1 class="text-2xl font-bold text-indigo-600">TeacherRate</h1>
+      <div class="flex items-center text-blue-700">
+        <i class="fa-solid fa-graduation-cap mr-2 text-3xl"></i>
+        <span class="text-2xl font-bold">TeacherRate</span>
+      </div>
       <nav class="flex items-center gap-4">
-        <a href="/" class="text-sm text-gray-600 hover:text-indigo-600">Home</a>
-        <a href="/admin" class="text-sm text-gray-600 hover:text-indigo-600">Admin</a>
+        <a href="/" class="text-sm text-gray-600 hover:text-blue-700">Home</a>
+        <a href="/admin" class="text-sm text-gray-600 hover:text-blue-700">Admin</a>
       </nav>
     </div>
   </header>
 
   <!-- Hero section -->
-  <section class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white py-20 text-center">
+  <section class="bg-gradient-to-r from-blue-700 to-blue-500 text-white py-20 text-center">
     <h2 class="text-4xl font-bold mb-4 animate__animated animate__fadeInDown">Share your classroom experiences</h2>
-    <p class="text-lg animate__animated animate__fadeInUp">Rate instructors and help students find the best teachers.</p>
+    <p class="text-lg animate__animated animate__fadeInUp">Rate instructors and help students make informed choices.</p>
   </section>
 
   <!-- Main content -->
   <main class="max-w-4xl mx-auto p-6 -mt-12">
     <!-- Teacher list -->
     <section class="animate__animated animate__fadeIn">
-      <h3 class="text-2xl font-semibold mb-4">Teachers</h3>
+      <h3 class="text-2xl font-semibold mb-4 text-blue-700">Teachers</h3>
       <div id="teachers" class="grid gap-6 sm:grid-cols-2"></div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- add graduation-cap logo and blue navigation styling for a more trustworthy feel
- replace purple gradient with blue tones and highlight teacher sections
- polish admin and review interfaces with consistent blue buttons and card borders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aaf6cea2a0832691e15e1bd8085013