### PR TITLE
Add loader animation and update admin credentials

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Admin Panel</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" />
+  <script src="loader.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-black text-green-500 font-mono">
   <header class="border-b border-green-700">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>TeachRate</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" />
+  <script src="loader.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-black text-green-500 font-mono">
   <header class="border-b border-green-700">

--- a/frontend/loader.js
+++ b/frontend/loader.js
@@ -1,0 +1,127 @@
+const style = document.createElement('style');
+style.textContent = `
+@keyframes blinkCursor {
+  50% {
+    border-right-color: transparent;
+  }
+}
+
+@keyframes typeAndDelete {
+  0%,
+  10% {
+    width: 0;
+  }
+  45%,
+  55% {
+    width: 6.2em;
+  }
+  90%,
+  100% {
+    width: 0;
+  }
+}
+
+.terminal-loader {
+  border: 0.1em solid #333;
+  background-color: #1a1a1a;
+  color: #0f0;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 1em;
+  padding: 1.5em 1em;
+  width: 12em;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.terminal-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1.5em;
+  background-color: #333;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  padding: 0 0.4em;
+  box-sizing: border-box;
+}
+
+.terminal-controls {
+  float: right;
+}
+
+.control {
+  display: inline-block;
+  width: 0.6em;
+  height: 0.6em;
+  margin-left: 0.4em;
+  border-radius: 50%;
+  background-color: #777;
+}
+
+.control.close {
+  background-color: #e33;
+}
+
+.control.minimize {
+  background-color: #ee0;
+}
+
+.control.maximize {
+  background-color: #0b0;
+}
+
+.terminal-title {
+  float: left;
+  line-height: 1.5em;
+  color: #eee;
+}
+
+.text {
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  border-right: 0.2em solid green;
+  animation:
+    typeAndDelete 4s steps(11) infinite,
+    blinkCursor 0.5s step-end infinite alternate;
+  margin-top: 1.5em;
+}
+`;
+document.head.appendChild(style);
+
+const loaderOverlay = document.createElement('div');
+loaderOverlay.id = 'loading-screen';
+loaderOverlay.style.position = 'fixed';
+loaderOverlay.style.top = '0';
+loaderOverlay.style.left = '0';
+loaderOverlay.style.width = '100%';
+loaderOverlay.style.height = '100%';
+loaderOverlay.style.display = 'flex';
+loaderOverlay.style.alignItems = 'center';
+loaderOverlay.style.justifyContent = 'center';
+loaderOverlay.style.backgroundColor = '#000';
+loaderOverlay.style.zIndex = '9999';
+
+loaderOverlay.innerHTML = `
+<div class="terminal-loader">
+  <div class="terminal-header">
+    <div class="terminal-title">Status</div>
+    <div class="terminal-controls">
+      <div class="control close"></div>
+      <div class="control minimize"></div>
+      <div class="control maximize"></div>
+    </div>
+  </div>
+  <div class="text">Loading...</div>
+</div>`;
+
+document.body.appendChild(loaderOverlay);
+
+window.addEventListener('load', () => {
+  loaderOverlay.remove();
+});
+

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Login</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" />
+  <script src="loader.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-black text-green-500 font-mono">
   <header class="border-b border-green-700">

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>My Reviews</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" />
+  <script src="loader.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-black text-green-500 font-mono">
   <header class="border-b border-green-700">

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Signup</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" />
+  <script src="loader.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-black text-green-500 font-mono">
   <header class="border-b border-green-700">

--- a/frontend/teacher.html
+++ b/frontend/teacher.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Teacher</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" />
+  <script src="loader.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-black text-green-500 font-mono">
   <header class="border-b border-green-700">

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ const sessions = new Map();
 
 // admin auth
 const adminSessions = new Set();
-const ADMIN = { username: 'admin', password: 'strawberry' };
+const ADMIN = { username: 'admin99', password: 'LaRive' };
 
 // ---- Helpers ---- //
 function averageFromReviews(reviews) {


### PR DESCRIPTION
## Summary
- Allow admin login with `admin99` and `LaRive` credentials
- Add terminal-style loading animation injected via `loader.js`
- Include loader script across frontend pages to show animation before content loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ac68a7010c832692c7446466a5de06